### PR TITLE
Don't use Buffer.allocUnsafe

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -34,7 +34,7 @@ function fromBech32 (address) {
 function toBase58Check (hash, version) {
   typeforce(types.tuple(types.Hash160bit, types.UInt8), arguments)
 
-  const payload = Buffer.allocUnsafe(21)
+  const payload = Buffer.alloc(21)
   payload.writeUInt8(version, 0)
   hash.copy(payload, 1)
 

--- a/src/block.js
+++ b/src/block.js
@@ -99,7 +99,7 @@ Block.prototype.getUTCDate = function () {
 
 // TODO: buffer, offset compatibility
 Block.prototype.toBuffer = function (headersOnly) {
-  const buffer = Buffer.allocUnsafe(this.byteLength(headersOnly))
+  const buffer = Buffer.alloc(this.byteLength(headersOnly))
 
   let offset = 0
   function writeSlice (slice) {

--- a/src/payments/p2pkh.js
+++ b/src/payments/p2pkh.js
@@ -45,7 +45,7 @@ function p2pkh (a, opts) {
   lazy.prop(o, 'address', function () {
     if (!o.hash) return
 
-    const payload = Buffer.allocUnsafe(21)
+    const payload = Buffer.alloc(21)
     payload.writeUInt8(network.pubKeyHash, 0)
     o.hash.copy(payload, 1)
     return bs58check.encode(payload)

--- a/src/payments/p2sh.js
+++ b/src/payments/p2sh.js
@@ -73,7 +73,7 @@ function p2sh (a, opts) {
   lazy.prop(o, 'address', function () {
     if (!o.hash) return
 
-    const payload = Buffer.allocUnsafe(21)
+    const payload = Buffer.alloc(21)
     payload.writeUInt8(network.scriptHash, 0)
     o.hash.copy(payload, 1)
     return bs58check.encode(payload)

--- a/src/script.js
+++ b/src/script.js
@@ -53,7 +53,7 @@ function compile (chunks) {
     return accum + 1
   }, 0.0)
 
-  const buffer = Buffer.allocUnsafe(bufferSize)
+  const buffer = Buffer.alloc(bufferSize)
   let offset = 0
 
   chunks.forEach(function (chunk) {
@@ -164,7 +164,7 @@ function toStack (chunks) {
 
   return chunks.map(function (op) {
     if (Buffer.isBuffer(op)) return op
-    if (op === OPS.OP_0) return Buffer.allocUnsafe(0)
+    if (op === OPS.OP_0) return Buffer.alloc(0)
 
     return scriptNumber.encode(op - OP_INT_BASE)
   })

--- a/src/script_number.js
+++ b/src/script_number.js
@@ -44,7 +44,7 @@ function scriptNumSize (i) {
 function encode (number) {
   let value = Math.abs(number)
   const size = scriptNumSize(value)
-  const buffer = Buffer.allocUnsafe(size)
+  const buffer = Buffer.alloc(size)
   const negative = number < 0
 
   for (var i = 0; i < size; ++i) {

--- a/src/script_signature.js
+++ b/src/script_signature.js
@@ -46,7 +46,7 @@ function encode (signature, hashType) {
   const hashTypeMod = hashType & ~0x80
   if (hashTypeMod <= 0 || hashTypeMod >= 4) throw new Error('Invalid hashType ' + hashType)
 
-  const hashTypeBuffer = Buffer.allocUnsafe(1)
+  const hashTypeBuffer = Buffer.alloc(1)
   hashTypeBuffer.writeUInt8(hashType, 0)
 
   const r = toDER(signature.slice(0, 32))

--- a/src/templates/witnesscommitment/output.js
+++ b/src/templates/witnesscommitment/output.js
@@ -22,7 +22,7 @@ check.toJSON = function () { return 'Witness commitment output' }
 function encode (commitment) {
   typeforce(types.Hash256bit, commitment)
 
-  const buffer = Buffer.allocUnsafe(36)
+  const buffer = Buffer.alloc(36)
   HEADER.copy(buffer, 0)
   commitment.copy(buffer, 4)
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -36,7 +36,7 @@ Transaction.SIGHASH_ANYONECANPAY = 0x80
 Transaction.ADVANCED_TRANSACTION_MARKER = 0x00
 Transaction.ADVANCED_TRANSACTION_FLAG = 0x01
 
-const EMPTY_SCRIPT = Buffer.allocUnsafe(0)
+const EMPTY_SCRIPT = Buffer.alloc(0)
 const EMPTY_WITNESS = []
 const ZERO = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
 const ONE = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex')
@@ -323,7 +323,7 @@ Transaction.prototype.hashForSignature = function (inIndex, prevOutScript, hashT
   }
 
   // serialize and hash
-  const buffer = Buffer.allocUnsafe(txTmp.__byteLength(false) + 4)
+  const buffer = Buffer.alloc(txTmp.__byteLength(false) + 4)
   buffer.writeInt32LE(hashType, buffer.length - 4)
   txTmp.__toBuffer(buffer, 0, false)
 
@@ -348,7 +348,7 @@ Transaction.prototype.hashForWitnessV0 = function (inIndex, prevOutScript, value
   let hashSequence = ZERO
 
   if (!(hashType & Transaction.SIGHASH_ANYONECANPAY)) {
-    tbuffer = Buffer.allocUnsafe(36 * this.ins.length)
+    tbuffer = Buffer.alloc(36 * this.ins.length)
     toffset = 0
 
     this.ins.forEach(function (txIn) {
@@ -362,7 +362,7 @@ Transaction.prototype.hashForWitnessV0 = function (inIndex, prevOutScript, value
   if (!(hashType & Transaction.SIGHASH_ANYONECANPAY) &&
        (hashType & 0x1f) !== Transaction.SIGHASH_SINGLE &&
        (hashType & 0x1f) !== Transaction.SIGHASH_NONE) {
-    tbuffer = Buffer.allocUnsafe(4 * this.ins.length)
+    tbuffer = Buffer.alloc(4 * this.ins.length)
     toffset = 0
 
     this.ins.forEach(function (txIn) {
@@ -378,7 +378,7 @@ Transaction.prototype.hashForWitnessV0 = function (inIndex, prevOutScript, value
       return sum + 8 + varSliceSize(output.script)
     }, 0)
 
-    tbuffer = Buffer.allocUnsafe(txOutsSize)
+    tbuffer = Buffer.alloc(txOutsSize)
     toffset = 0
 
     this.outs.forEach(function (out) {
@@ -390,7 +390,7 @@ Transaction.prototype.hashForWitnessV0 = function (inIndex, prevOutScript, value
   } else if ((hashType & 0x1f) === Transaction.SIGHASH_SINGLE && inIndex < this.outs.length) {
     const output = this.outs[inIndex]
 
-    tbuffer = Buffer.allocUnsafe(8 + varSliceSize(output.script))
+    tbuffer = Buffer.alloc(8 + varSliceSize(output.script))
     toffset = 0
     writeUInt64(output.value)
     writeVarSlice(output.script)
@@ -398,7 +398,7 @@ Transaction.prototype.hashForWitnessV0 = function (inIndex, prevOutScript, value
     hashOutputs = bcrypto.hash256(tbuffer)
   }
 
-  tbuffer = Buffer.allocUnsafe(156 + varSliceSize(prevOutScript))
+  tbuffer = Buffer.alloc(156 + varSliceSize(prevOutScript))
   toffset = 0
 
   const input = this.ins[inIndex]
@@ -430,7 +430,7 @@ Transaction.prototype.toBuffer = function (buffer, initialOffset) {
 }
 
 Transaction.prototype.__toBuffer = function (buffer, initialOffset, __allowWitness) {
-  if (!buffer) buffer = Buffer.allocUnsafe(this.__byteLength(__allowWitness))
+  if (!buffer) buffer = Buffer.alloc(this.__byteLength(__allowWitness))
 
   let offset = initialOffset || 0
   function writeSlice (slice) { offset += slice.copy(buffer, offset) }


### PR DESCRIPTION
Replace all occurrences of `Buffer.allocUnsafe(` with `Buffer.alloc(`.